### PR TITLE
Performance: make JpegStreamReader\Writer a struct

### DIFF
--- a/src/JpegLSDecoder.cs
+++ b/src/JpegLSDecoder.cs
@@ -10,7 +10,7 @@ namespace CharLS.Managed;
 /// </summary>
 public sealed class JpegLSDecoder
 {
-    private readonly JpegStreamReader _reader;
+    private JpegStreamReader _reader;
     private State _state = State.Initial;
 
     private enum State

--- a/src/JpegLSEncoder.cs
+++ b/src/JpegLSEncoder.cs
@@ -12,7 +12,7 @@ namespace CharLS.Managed;
 /// </summary>
 public sealed class JpegLSEncoder
 {
-    private readonly JpegStreamWriter _writer = new();
+    private JpegStreamWriter _writer;
     private FrameInfo? _frameInfo;
     private int _nearLossless;
     private InterleaveMode _interleaveMode;

--- a/src/JpegStreamReader.cs
+++ b/src/JpegStreamReader.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace CharLS.Managed;
 
-internal class JpegStreamReader
+internal struct JpegStreamReader
 {
     private enum State
     {
@@ -54,6 +54,12 @@ internal class JpegStreamReader
     internal uint RestartInterval
     {
         get { return _restartInterval; }
+    }
+
+    public JpegStreamReader()
+    {
+        _eventSender = this;
+        _componentIds = [];
     }
 
     internal JpegStreamReader(object? eventSender = null)

--- a/src/JpegStreamWriter.cs
+++ b/src/JpegStreamWriter.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace CharLS.Managed;
 
-internal class JpegStreamWriter
+internal struct JpegStreamWriter
 {
     private int _position;
     private int _componentIndex;


### PR DESCRIPTION
Both classes are always embedded in their parent class. It is more efficient to defines these internal types as structs.