### PR TITLE
Forward the stride parameter

### DIFF
--- a/test/ComplianceTest.cs
+++ b/test/ComplianceTest.cs
@@ -48,7 +48,7 @@ public class ComplianceTest
     }
 
     [Fact]
-    public void DecodeEncodeColor8BitInterleaveLineLosslessNonDefault()
+    public void DecodeEncodeColor8BitInterleaveNoneLosslessNonDefault()
     {
         // ISO 14495-1: official test image 9 (T87_test-1-2-3-4-5-6.zip)
         // NON-DEFAULT parameters T1=T2=T3=9,RESET=31.
@@ -56,7 +56,7 @@ public class ComplianceTest
     }
 
     [Fact]
-    public void DecodeEncodeColor8BitInterleaveLineNearLossless3NonDefault()
+    public void DecodeEncodeColor8BitInterleaveNoneNearLossless3NonDefault()
     {
         // ISO 14495-1: official test image 10 (T87_test-1-2-3-4-5-6.zip)
         // NON-DEFAULT parameters T1=T2=T3=9,RESET=31.

--- a/test/CopyFromLineBufferTest.cs
+++ b/test/CopyFromLineBufferTest.cs
@@ -6,16 +6,16 @@ namespace CharLS.Managed.Test;
 public class CopyFromLineBufferTest
 {
     [Fact]
-    public void GetMethod8BitInterleaveModeNone()
+    public void GetCopyMethod8BitInterleaveModeNone()
     {
-        var method = CopyFromLineBuffer.GetMethod(8, 1, InterleaveMode.None, ColorTransformation.None);
+        var method = CopyFromLineBuffer.GetCopyMethod(8, InterleaveMode.None, 1,  ColorTransformation.None);
         Assert.NotNull(method);
     }
 
     [Fact]
-    public void GetMethod16BitInterleaveModeNone()
+    public void GetCopyMethod16BitInterleaveModeNone()
     {
-        var method = CopyFromLineBuffer.GetMethod(16, 1, InterleaveMode.None, ColorTransformation.None);
+        var method = CopyFromLineBuffer.GetCopyMethod(16, InterleaveMode.None, 1,  ColorTransformation.None);
         Assert.NotNull(method);
     }
 }


### PR DESCRIPTION
- The stride parameter is only used during decoding. Don't store it as member, but just forward it as parameter (number of parameters is still below 3)
- Align with C++ implementation