### PR TITLE
Increase the version to 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- Internal improvements
+
 ## [0.8.0 - 2024-8-23]
 
 ### Added

--- a/CharLSDotNet.sln
+++ b/CharLSDotNet.sln
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
 		.globalconfig = .globalconfig
+		CHANGELOG.md = CHANGELOG.md
 		Directory.Build.props = Directory.Build.props
 		Directory.Packages.props = Directory.Packages.props
 		exclusion.dic = exclusion.dic
@@ -23,7 +24,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CharLS.Managed.Test", "test
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CharLS.Managed.Benchmark", "benchmark\CharLS.Managed.Benchmark.csproj", "{43E730B3-BCBC-40A8-8F32-72FC278300D5}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "samples", "{A9E95F06-F2ED-46F9-8AE7-9EBE15768205}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{A9E95F06-F2ED-46F9-8AE7-9EBE15768205}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Convert", "samples\Convert\Convert.csproj", "{601E8408-2608-403C-B1E6-E78244506CAB}"
 EndProject
@@ -53,10 +54,10 @@ Global
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {56485FF1-DC2F-4331-B71C-DFD115C8711C}
-	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{601E8408-2608-403C-B1E6-E78244506CAB} = {A9E95F06-F2ED-46F9-8AE7-9EBE15768205}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {56485FF1-DC2F-4331-B71C-DFD115C8711C}
 	EndGlobalSection
 EndGlobal

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,9 +19,9 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 
     <!-- Version information -->
-    <Version>0.8.0</Version>
+    <Version>0.8.1</Version>
     <AssemblyVersion>0.8.0.0</AssemblyVersion>
-    <FileVersion>0.8.0.0</FileVersion>
+    <FileVersion>0.8.1.0</FileVersion>
     <Copyright>Copyright 2024 Team CharLS</Copyright>
 
     <!-- Build -->

--- a/test/ComplianceTest.cs
+++ b/test/ComplianceTest.cs
@@ -87,7 +87,7 @@ public class ComplianceTest
     }
 
     [Fact]
-    public void DecodeEncodeTulipsMonochrome8BitLosslessHpForMeasurement()
+    public void DecodeTulipsMonochrome8BitLosslessHpForMeasurement()
     {
         var encodedSource = Util.ReadFile("test-images/tulips-gray-8bit-512-512-hp-encoder.jls");
 


### PR DESCRIPTION
Increase the version number to make it clear that the version on the main branch isn't the source code of the NuGet package 0.8.0 No decision has been made which version number will be used for the next NuGet package release.