### PR TITLE
Apply some micro benchmark improvements

### DIFF
--- a/benchmark/Micro/ComputeReconstructedSample.cs
+++ b/benchmark/Micro/ComputeReconstructedSample.cs
@@ -18,11 +18,11 @@ public class ComputeReconstructedSample
     [GlobalSetup]
     public void Init()
     {
-        _traits = new Traits(256, 0, 64);
-        _traitsLossy = new Traits(256, 3, 64);
-        _losslessTraits = new LosslessTraits(256, 0, 64);
-        _losslessTraits8 = new LosslessTraits8(256, 0, 64);
-        _losslessTraits16 = new LosslessTraits16(256, 0, 64);
+        _traits = new Traits(256, 0);
+        _traitsLossy = new Traits(256, 3);
+        _losslessTraits = new LosslessTraits(256, 0);
+        _losslessTraits8 = new LosslessTraits8(256, 0);
+        _losslessTraits16 = new LosslessTraits16(256, 0);
         _predictedValue = 256;
         _errorValue = 240;
     }

--- a/exclusion.dic
+++ b/exclusion.dic
@@ -8,3 +8,4 @@ Cmyk
 Ycck
 opto
 palletised
+glimit

--- a/src/Algorithm.cs
+++ b/src/Algorithm.cs
@@ -2,11 +2,31 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 using System.Numerics;
+using System.Runtime.CompilerServices;
 
 namespace CharLS.Managed;
 
 internal static class Algorithm
 {
+    /// <summary>
+    /// Abs, but without the check for overflow.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static int AbsUnchecked(int value)
+    {
+        Debug.Assert(value != int.MinValue);
+        return value < 0 ? -value : value;
+    }
+
+    /// <summary>
+    /// Checks if a value is outside the range [-range, range].
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool OutsideRange(int value, int range)
+    {
+        return value < -range || value > range;
+    }
+
     internal static int Log2Ceiling(int value)
     {
         Debug.Assert(value >= 0);

--- a/src/Constants.cs
+++ b/src/Constants.cs
@@ -27,8 +27,6 @@ internal static class Constants
     internal const int AutoCalculateStride = 0;
     internal const byte JpegMarkerStartByte = 0xFF;
 
-    internal const int MaxKValue = 16; // This is an implementation limit (theoretical limit is 32)
-
     // ISO/IEC 14495-1, section 4.8.1 defines the SPIFF version numbers to be used for the SPIFF header in combination with
     // JPEG-LS.
     internal const byte SpiffMajorRevisionNumber = 2;

--- a/src/CopyFromLineBuffer.cs
+++ b/src/CopyFromLineBuffer.cs
@@ -25,7 +25,7 @@ internal class CopyFromLineBuffer
         switch (interleaveMode)
         {
             case InterleaveMode.None:
-                return CopySamples8Bit;
+                return NotUsed;
 
             case InterleaveMode.Line:
                 switch (componentCount)
@@ -79,7 +79,7 @@ internal class CopyFromLineBuffer
         switch (interleaveMode)
         {
             case InterleaveMode.None:
-                return CopySamples16Bit;
+                return NotUsed;
 
             case InterleaveMode.Line:
                 switch (componentCount)
@@ -128,9 +128,9 @@ internal class CopyFromLineBuffer
         }
     }
 
-    private static void CopySamples8Bit(Span<byte> source, Span<byte> destination, int pixelCount)
+    private static void NotUsed(Span<byte> source, Span<byte> destination, int pixelCount)
     {
-        source[..pixelCount].CopyTo(destination);
+        Debug.Assert(false);
     }
 
     private static void CopyLine8Bit3Components(Span<byte> source, Span<byte> destination, int pixelCount)
@@ -239,11 +239,6 @@ internal class CopyFromLineBuffer
             var pixel = sourceTriplet[i];
             destinationTriplet[i] = ColorTransformations.ReverseTransformHP3(pixel.V1, pixel.V2, pixel.V3);
         }
-    }
-
-    private static void CopySamples16Bit(Span<byte> source, Span<byte> destination, int pixelCount)
-    {
-        source[..(pixelCount * 2)].CopyTo(destination);
     }
 
     private static void CopyLine16Bit3Components(Span<byte> source, Span<byte> destination, int pixelCount)

--- a/src/JpegLSDecoder.cs
+++ b/src/JpegLSDecoder.cs
@@ -200,7 +200,7 @@ public sealed class JpegLSDecoder
     {
         CheckHeaderRead();
         ThrowHelper.ThrowIfOutsideRange(0, _reader.ComponentCount - 1, componentIndex);
-        return _reader.GetCodingParameters().NearLossless;
+        return _reader.GetNearLossless(componentIndex);
     }
 
     /// <summary>

--- a/src/LosslessTraits.cs
+++ b/src/LosslessTraits.cs
@@ -5,8 +5,8 @@ namespace CharLS.Managed;
 
 internal class LosslessTraits : Traits
 {
-    internal LosslessTraits(int maximumSampleValue, int nearLossless, int resetThreshold)
-        : base(maximumSampleValue, nearLossless, resetThreshold)
+    internal LosslessTraits(int maximumSampleValue, int nearLossless)
+        : base(maximumSampleValue, nearLossless)
     {
     }
 

--- a/src/LosslessTraits16.cs
+++ b/src/LosslessTraits16.cs
@@ -3,8 +3,8 @@
 
 namespace CharLS.Managed;
 
-internal sealed class LosslessTraits16(int maximumSampleValue, int nearLossless, int resetThreshold)
-    : LosslessTraits(maximumSampleValue, nearLossless, resetThreshold)
+internal sealed class LosslessTraits16(int maximumSampleValue, int nearLossless)
+    : LosslessTraits(maximumSampleValue, nearLossless)
 {
     internal override int ComputeErrorValue(int errorValue)
     {

--- a/src/LosslessTraits8.cs
+++ b/src/LosslessTraits8.cs
@@ -3,8 +3,8 @@
 
 namespace CharLS.Managed;
 
-internal sealed class LosslessTraits8(int maximumSampleValue, int nearLossless, int resetThreshold)
-    : LosslessTraits(maximumSampleValue, nearLossless, resetThreshold)
+internal sealed class LosslessTraits8(int maximumSampleValue, int nearLossless)
+    : LosslessTraits(maximumSampleValue, nearLossless)
 {
     internal override int ComputeErrorValue(int errorValue)
     {

--- a/src/ThrowHelper.cs
+++ b/src/ThrowHelper.cs
@@ -21,7 +21,7 @@ internal static class ThrowHelper
         throw AddErrorCode(new ArgumentException(GetErrorMessage(errorCode), paramName), errorCode);
     }
 
-    internal static void ThrowArgumentOutOfRangeExceptionIfFalse(bool condition, ErrorCode errorCode, string? paramName = null)
+    internal static void ThrowArgumentOutOfRangeExceptionIfFalse([DoesNotReturnIf(false)] bool condition, ErrorCode errorCode, string? paramName = null)
     {
         if (condition)
             return;
@@ -43,7 +43,7 @@ internal static class ThrowHelper
             ThrowArgumentOutOfRangeException(errorCode, paramName);
     }
 
-    internal static void ThrowInvalidOperationIfFalse(bool condition)
+    internal static void ThrowInvalidOperationIfFalse([DoesNotReturnIf(false)] bool condition)
     {
         if (condition)
             return;
@@ -51,7 +51,7 @@ internal static class ThrowHelper
         ThrowInvalidOperationException();
     }
 
-    internal static void ThrowArgumentExceptionIfFalse(bool value, string? paramName = null, ErrorCode errorCode = ErrorCode.InvalidArgument)
+    internal static void ThrowArgumentExceptionIfFalse([DoesNotReturnIf(false)] bool value, string? paramName = null, ErrorCode errorCode = ErrorCode.InvalidArgument)
     {
         if (value)
             return;

--- a/src/Traits.cs
+++ b/src/Traits.cs
@@ -7,16 +7,12 @@ namespace CharLS.Managed;
 
 internal class Traits
 {
-    internal Traits(int maximumSampleValue, int nearLossless, int resetThreshold = Constants.DefaultResetThreshold)
+    internal Traits(int maximumSampleValue, int nearLossless)
     {
         MaximumSampleValue = maximumSampleValue;
         Range = ComputeRangeParameter(maximumSampleValue, nearLossless);
         NearLossless = nearLossless;
-        QuantizedBitsPerSample = Log2Ceiling(Range);
         BitsPerSample = Log2Ceiling(maximumSampleValue);
-        Limit = ComputeLimitParameter(BitsPerSample);
-        ResetThreshold = resetThreshold;
-        QuantizationRange = 1 << BitsPerSample;
     }
 
     /// <summary>
@@ -33,23 +29,6 @@ internal class Traits
     /// ISO 14495-1 RANGE symbol: range of prediction error representation.
     /// </summary>
     internal int Range { get; }
-
-    /// <summary>
-    /// ISO 14495-1 qbpp symbol: number of bits needed to represent a mapped error value.
-    /// </summary>
-    internal int QuantizedBitsPerSample { get; }
-
-    /// <summary>
-    /// ISO 14495-1 LIMIT symbol: the value of glimit for a sample encoded in regular mode.
-    /// </summary>
-    internal int Limit { get; }
-
-    /// <summary>
-    /// ISO 14495-1 RESET symbol: threshold value at which A, B, and N are halved.
-    /// </summary>
-    internal int ResetThreshold { get; }
-
-    internal int QuantizationRange { get; }
 
     /// <summary>
     /// ISO 14495-1 NEAR symbol: difference bound for near-lossless coding, 0 means lossless.
@@ -124,18 +103,18 @@ internal class Traits
                Math.Abs(lhs.V3 - rhs.V3) <= NearLossless && Math.Abs(lhs.V4 - rhs.V4) <= NearLossless;
     }
 
-    internal static Traits Create(FrameInfo frameInfo, int nearLossless, int resetThreshold)
+    internal static Traits Create(FrameInfo frameInfo, int nearLossless)
     {
         int maximumSampleValue = CalculateMaximumSampleValue(frameInfo.BitsPerSample);
 
         if (nearLossless != 0)
-            return new Traits(maximumSampleValue, nearLossless, resetThreshold);
+            return new Traits(maximumSampleValue, nearLossless);
 
         return frameInfo.BitsPerSample switch
         {
-            8 => new LosslessTraits8(maximumSampleValue, nearLossless, resetThreshold),
-            16 => new LosslessTraits16(maximumSampleValue, nearLossless, resetThreshold),
-            _ => new LosslessTraits(maximumSampleValue, nearLossless, resetThreshold)
+            8 => new LosslessTraits8(maximumSampleValue, nearLossless),
+            16 => new LosslessTraits16(maximumSampleValue, nearLossless),
+            _ => new LosslessTraits(maximumSampleValue, nearLossless)
         };
     }
 


### PR DESCRIPTION
- Move parameters used during encoding/decoding from Traits (class) to ScanCodec (struct) to save 1 indirection.
- Use custom Abs (skips checking for overflow)