### PR TITLE
Optimize the checking in ComputeGolombCodingParameterChecked

### DIFF
--- a/benchmark/Micro/GolombCodingParameter.cs
+++ b/benchmark/Micro/GolombCodingParameter.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
+
+using System.Numerics;
+using BenchmarkDotNet.Attributes;
+
+namespace CharLS.Managed.Benchmark.Micro;
+
+public class GolombCodingParameter
+{
+    private int[]? _nValues;
+    private int[]? _aValues;
+
+    [GlobalSetup]
+    public void Init()
+    {
+        // Use as input values that will return k as [0, 1, 2, 3, 4, 5, 6]
+        // Remark: this input is even distributed, real JPEG-LS images have a different distribution.
+        _nValues = [3, 39, 56, 35, 53, 60, 52, 50, 35];
+        _aValues = [107, 56, 124, 33, 249, 56, 478, 1259, 41];
+    }
+
+    [Benchmark]
+    public int ComputeOriginalChecked()
+    {
+        int total = 0;
+
+        for (int i = 0; i != _nValues!.Length; ++i)
+        {
+            total += ComputeGolombCodingParameterChecked(_nValues[i], _aValues![i]);
+        }
+
+        return total;
+    }
+
+    [Benchmark]
+    public int ComputeOriginalCheckAfter()
+    {
+        int total = 0;
+
+        for (int i = 0; i != _nValues!.Length; ++i)
+        {
+            total += ComputeGolombCodingParameterCheckAfter(_nValues[i], _aValues![i]);
+        }
+
+        return total;
+    }
+
+    [Benchmark]
+    public int ComputeGolombCodingParameterLeadingZeroCount()
+    {
+        int total = 0;
+
+        for (int i = 0; i != _nValues!.Length; ++i)
+        {
+            total += ComputeGolombCodingParameterLeadingZeroCount(_nValues[i], _aValues![i]);
+        }
+
+        return total;
+    }
+
+    private static int ComputeGolombCodingParameterChecked(int n, int a)
+    {
+        const int maxKValue = 16; // This is an implementation limit (theoretical limit is 32)
+
+        int k = 0;
+        for (; n << k < a && k < maxKValue; ++k)
+        {
+            // Purpose of this loop is to calculate 'k', by design no content.
+        }
+
+        if (k == maxKValue)
+            ThrowHelper.ThrowInvalidDataException(ErrorCode.InvalidData);
+
+        return k;
+    }
+
+    private static int ComputeGolombCodingParameterCheckAfter(int n, int a)
+    {
+        const int maxKValue = 16;
+        int k = ComputeGolombCodingParameter(n, a);
+        if (k >= maxKValue)
+            ThrowHelper.ThrowInvalidDataException(ErrorCode.InvalidData);
+
+        return k;
+    }
+
+    private static int ComputeGolombCodingParameter(int n, int a)
+    {
+        int k = 0;
+        for (; n << k < a; ++k)
+        {
+            // Purpose of this loop is to calculate 'k', by design no content.
+        }
+
+        return k;
+    }
+
+    private static int ComputeGolombCodingParameterLeadingZeroCount(int n, int a)
+    {
+        int nZeroCount = BitOperations.LeadingZeroCount((uint)n);
+        int aZeroCount = BitOperations.LeadingZeroCount((uint)a);
+        int k = nZeroCount - aZeroCount;
+        if (k < 0)
+            return 0;
+
+        if ((n << k) < a)
+        {
+            ++k;
+        }
+
+        const int maxKValue = 16;
+        if (k >= maxKValue)
+            ThrowHelper.ThrowInvalidDataException(ErrorCode.InvalidData);
+
+        return k;
+    }
+}

--- a/exclusion.dic
+++ b/exclusion.dic
@@ -9,3 +9,4 @@ Ycck
 opto
 palletised
 glimit
+Golomb

--- a/src/Algorithm.cs
+++ b/src/Algorithm.cs
@@ -33,10 +33,9 @@ internal static class Algorithm
         Debug.Assert((uint)value <= uint.MaxValue >> 2); // otherwise 1 << x becomes negative.
 
         int log2Floor = BitOperations.Log2((uint)value);
-        bool isPowerOfTwo = (value & (value - 1)) == 0;
 
         // If value is not a power of two, add 1 to get the ceiling
-        return isPowerOfTwo ? log2Floor : log2Floor + 1;
+        return BitOperations.IsPow2(value) ? log2Floor : log2Floor + 1;
     }
 
     /// <summary>

--- a/src/RegularModeContext.cs
+++ b/src/RegularModeContext.cs
@@ -27,15 +27,10 @@ internal struct RegularModeContext
     /// </remarks>
     internal readonly int ComputeGolombCodingParameterChecked()
     {
-        const int maxKValue = 16; // This is an implementation limit (theoretical limit is 32)
+        const int maxKValue = 16; // This is an implementation limit as there are only 16 lookup tables (theoretical limit is 32)
 
-        int k = 0;
-        for (; _n << k < _a && k < maxKValue; ++k)
-        {
-            // Purpose of this loop is to calculate 'k', by design no content.
-        }
-
-        if (k == maxKValue)
+        int k = ComputeGolombCodingParameter();
+        if (k >= maxKValue)
             ThrowHelper.ThrowInvalidDataException(ErrorCode.InvalidData);
 
         return k;
@@ -64,6 +59,7 @@ internal struct RegularModeContext
     internal void UpdateVariablesAndBias(int errorValue, int nearLossless, int resetThreshold)
     {
         Debug.Assert(_n != 0);
+        Debug.Assert(resetThreshold >= 3);
 
         _a += AbsUnchecked(errorValue);
         _b += errorValue * ((2 * nearLossless) + 1);
@@ -75,7 +71,7 @@ internal struct RegularModeContext
         if (_n == resetThreshold)
         {
             _a >>= 1;
-            _b >>= 1;
+            _b >>= 1; // Note: C# performs arithmetic right shift on signed integers, handling _b < 0 case is not needed.
             _n >>= 1;
         }
 

--- a/test/RegularModeContextTest.cs
+++ b/test/RegularModeContextTest.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
+
+using System.Numerics;
+
+namespace CharLS.Managed.Test;
+
+public class RegularModeContextTest
+{
+    [Fact]
+    public void ComputeGolombCodingParameterAlgorithm()
+    {
+        Assert.Equal(ComputeGolombCodingParameterLocal(2, 5), ComputeGolombCodingParameterLocalLeadingZeroCount(2,5));
+        Assert.Equal(ComputeGolombCodingParameterLocal(3, 5), ComputeGolombCodingParameterLocalLeadingZeroCount(3, 5));
+        Assert.Equal(ComputeGolombCodingParameterLocal(16, 6), ComputeGolombCodingParameterLocalLeadingZeroCount(16, 6));
+    }
+
+    private static int ComputeGolombCodingParameterLocalLeadingZeroCount(int n, int a)
+    {
+        int nZeroCount = BitOperations.LeadingZeroCount((uint)n);
+        int aZeroCount = BitOperations.LeadingZeroCount((uint)a);
+        int k = nZeroCount - aZeroCount;
+        if (k < 0)
+            return 0;
+
+        if ((n << k) < a)
+        {
+            ++k;
+        }
+
+        const int maxKValue = 16;
+        if (k >= maxKValue)
+            ThrowHelper.ThrowInvalidDataException(ErrorCode.InvalidData);
+
+        return k;
+    }
+
+    private static int ComputeGolombCodingParameterLocal(int n, int a)
+    {
+        int k = 0;
+        for (; (n << k) < a; ++k)
+        {
+            // Purpose of this loop is to calculate 'k', by design no content.
+        }
+
+        const int maxKValue = 16;
+        if (k >= maxKValue)
+            ThrowHelper.ThrowInvalidDataException(ErrorCode.InvalidData);
+        return k;
+    }
+}


### PR DESCRIPTION
Add a benchmark and optimize the method (move the check) An alternative method is slightly faster in micro becnhmark but with real data image decoding speed decreases from 250 ms to 300 ms for mg1.jls image.