### PR TITLE
Enable using lossless traits during encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- New property JpegLSDecoder.CompressedDataFormat to retrieve the compressed data format of 
+the JPEG-LS file. JPEG-LS defines 3 formats: 1 interchange (most common) and 2 abbreviated.
+
 ### Changed
 
-- Internal improvements
+- Internal improvements.
+- Improved lossless encoding speed by speedup ratio of 1.2.
 
 ## [0.8.0 - 2024-8-23]
 

--- a/benchmark/EncodeMonochrome.cs
+++ b/benchmark/EncodeMonochrome.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
+
+using BenchmarkDotNet.Attributes;
+
+namespace CharLS.Managed.Benchmark;
+
+public class EncodeMonochrome
+{
+    private byte[]? _source;
+    private byte[]? _destination;
+    private PortableAnymapFile? _referenceFile;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _referenceFile = new PortableAnymapFile("d:/benchmark-test-image.pgm");
+
+        _source = _referenceFile.ImageData;
+
+        var encoder = new JpegLSEncoder(
+            _referenceFile.Width, _referenceFile.Height, _referenceFile.BitsPerSample, _referenceFile.ComponentCount);
+        _destination = new byte[encoder.EstimatedDestinationSize];
+    }
+
+    [Benchmark]
+    public void EncodeLossless()
+    {
+        var encoder = new JpegLSEncoder(
+            _referenceFile!.Width, _referenceFile.Height, _referenceFile.BitsPerSample, _referenceFile.ComponentCount, InterleaveMode.None, false)
+        {
+            Destination = _destination
+        };
+
+        encoder.Encode(_source);
+    }
+
+    [Benchmark]
+    public void EncodeLossy()
+    {
+        var encoder = new JpegLSEncoder(
+            _referenceFile!.Width, _referenceFile.Height, _referenceFile.BitsPerSample, _referenceFile.ComponentCount, InterleaveMode.None, false)
+        {
+            Destination = _destination,
+            NearLossless = 3
+        };
+
+        encoder.Encode(_source);
+    }
+}

--- a/benchmark/PortableAnymapFile.cs
+++ b/benchmark/PortableAnymapFile.cs
@@ -1,0 +1,146 @@
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
+
+using System.Text;
+
+namespace CharLS.Managed.Benchmark;
+
+internal sealed class PortableAnymapFile
+{
+    internal int ComponentCount { get; set; }
+    internal int Width { get; set; }
+    internal int Height { get; set; }
+    internal int BitsPerSample { get; set; }
+
+    internal byte[] ImageData { get; set; }
+
+    internal PortableAnymapFile(string filename)
+    {
+        using var fs = new FileStream(filename, FileMode.Open, FileAccess.Read);
+
+        List<int> headerInfo = ReadHeader(fs);
+        if (headerInfo.Count != 4)
+            throw new InvalidDataException("Incorrect PNM header");
+
+        ComponentCount = headerInfo[0] == 6 ? 3 : 1;
+        Width = headerInfo[1];
+        Height = headerInfo[2];
+        BitsPerSample = Log2(headerInfo[3] + 1);
+
+        int bytesPerSample = (BitsPerSample + 7) / 8;
+
+        byte[] imageData = new byte[Width * Height * bytesPerSample * ComponentCount];
+        int bytesRead = fs.Read(imageData, 0, imageData.Length);
+        if (bytesRead != imageData.Length)
+            throw new InvalidDataException("Missing image data");
+
+        if (bytesPerSample == 2)
+        {
+            // Anymap files with multibyte pixels are stored in big endian format in the file.
+            ConvertToLittleEndian(imageData);
+        }
+
+        ImageData = imageData;
+    }
+
+    private static List<int> ReadHeader(Stream pnmFile)
+    {
+        List<int> result = [];
+
+        byte first = (byte)pnmFile.ReadByte();
+
+        // All portable anymap format (PNM) start with the character P.
+        if (first != 'P')
+            throw new InvalidDataException("Missing P");
+
+        using UnbufferedStreamReader sr = new(pnmFile);
+
+        while (result.Count < 4)
+        {
+            string line = sr.ReadLine();
+            if (IsCommentLine(line))
+                continue;
+
+            string[] tokens = line.Split();
+            foreach (var token in tokens)
+            {
+                if (int.TryParse(token, out int value))
+                {
+                    result.Add(value);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static bool IsCommentLine(string line)
+    {
+        line = line.TrimStart();
+        return line.Length > 0 && line[0] == '#';
+    }
+
+    private static int Log2(int n)
+    {
+        int x = 0;
+        while (n > (1 << x))
+        {
+            ++x;
+        }
+        return x;
+    }
+
+    private static void ConvertToLittleEndian(byte[] imageBytes)
+    {
+        for (int i = 0; i < imageBytes.Length - 1; i += 2)
+        {
+            (imageBytes[i], imageBytes[i + 1]) = (imageBytes[i + 1], imageBytes[i]);
+        }
+    }
+
+    private sealed class UnbufferedStreamReader(Stream stream) : TextReader
+    {
+        // This method assumes lines end with a line feed.
+        // You may need to modify this method if your stream
+        // follows the Windows convention of \r\n or some other 
+        // convention that isn't just \n
+        public override string ReadLine()
+        {
+            List<byte> bytes = [];
+            int current;
+            while ((current = Read()) != -1 && current != '\n')
+            {
+                byte b = (byte)current;
+                bytes.Add(b);
+            }
+            return Encoding.ASCII.GetString(bytes.ToArray());
+        }
+
+        // Read works differently than the `Read()` method of a 
+        // TextReader. It reads the next BYTE rather than the next character
+        public override int Read()
+        {
+            return stream.ReadByte();
+        }
+
+        public override int Read(char[] buffer, int index, int count)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int Peek()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int ReadBlock(char[] buffer, int index, int count)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string ReadToEnd()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/LosslessTraits16.cs
+++ b/src/LosslessTraits16.cs
@@ -13,7 +13,7 @@ internal sealed class LosslessTraits16(int maximumSampleValue, int nearLossless)
 
     internal override int ComputeReconstructedSample(int predictedValue, int errorValue)
     {
-        return predictedValue + errorValue;
+        return (ushort)(predictedValue + errorValue);
     }
 
     internal override int ModuloRange(int errorValue)

--- a/src/LosslessTraits8.cs
+++ b/src/LosslessTraits8.cs
@@ -13,7 +13,7 @@ internal sealed class LosslessTraits8(int maximumSampleValue, int nearLossless)
 
     internal override int ComputeReconstructedSample(int predictedValue, int errorValue)
     {
-        return predictedValue + errorValue;
+        return (byte)(predictedValue + errorValue);
     }
 
     internal override int ModuloRange(int errorValue)

--- a/src/ScanEncoder.cs
+++ b/src/ScanEncoder.cs
@@ -22,8 +22,7 @@ internal struct ScanEncoder
 
     internal ScanEncoder(FrameInfo frameInfo, JpegLSPresetCodingParameters presetCodingParameters, CodingParameters codingParameters)
     {
-        int maximumSampleValue = CalculateMaximumSampleValue(frameInfo.BitsPerSample);
-        var traits = new Traits(maximumSampleValue, codingParameters.NearLossless);
+        var traits = Traits.Create(frameInfo, codingParameters.NearLossless);
         _scanCodec = new ScanCodec(traits, frameInfo, presetCodingParameters, codingParameters);
 
         _mask = (1 << frameInfo.BitsPerSample) - 1;


### PR DESCRIPTION
2 casts were lost during the conversion from C++ to C#, add them back and activate using the lossless traits. Add a benchmark to measure lossless and lossy decoding speed.