### PR TITLE
Extend API of JpegLSEncoder with EncodeComponents methods

### DIFF
--- a/src/Constants.cs
+++ b/src/Constants.cs
@@ -9,6 +9,7 @@ internal static class Constants
 
     internal const int MinimumComponentCount = 1;
     internal const int MaximumComponentCount = 255;
+    internal const int MaximumComponentCountInScan = 4;
     internal const int MinimumComponentIndex = 0;
     internal const int MaximumComponentIndex = MaximumComponentCount - 1;
     internal const int MinimumBitsPerSample = 2;

--- a/src/ScanDecoder.cs
+++ b/src/ScanDecoder.cs
@@ -35,7 +35,7 @@ internal struct ScanDecoder
 
     internal ScanDecoder(FrameInfo frameInfo, JpegLSPresetCodingParameters presetCodingParameters, CodingParameters codingParameters)
     {
-        var traits = Traits.Create(frameInfo, codingParameters.NearLossless);
+        var traits = Traits.Create(frameInfo.BitsPerSample, codingParameters.NearLossless);
         _scanCodec = new ScanCodec(traits, frameInfo, presetCodingParameters, codingParameters);
 
         _copyFromLineBuffer = CopyFromLineBuffer.GetCopyMethod(
@@ -416,11 +416,11 @@ internal struct ScanDecoder
         {
             int linesInInterval = Math.Min(FrameInfo.Height - line, _restartInterval);
 
-            for (int mcu = 0; mcu < linesInInterval; ++mcu, ++line)
+            for (int mcu = 0; ;)
             {
                 var previousLine = lineBuffer;
                 var currentLine = lineBuffer[pixelStride..];
-                if ((line & 1) == 1)
+                if ((mcu & 1) == 1)
                 {
                     var temp = previousLine;
                     previousLine = currentLine;
@@ -434,12 +434,21 @@ internal struct ScanDecoder
                 DecodeSampleLine(previousLine, currentLine);
 
                 CopyLineBufferToDestinationInterleaveNone(currentLine[1..], destination, FrameInfo.Width);
+
+                ++mcu;
+                if (mcu == linesInInterval)
+                {
+                    line += mcu;
+                    break;
+                }
+
                 destination = destination[stride..];
             }
 
             if (line == FrameInfo.Height)
                 break;
 
+            destination = destination[stride..];
             ProcessRestartMarker();
 
             // After a restart marker it is required to reset the decoder.
@@ -458,11 +467,11 @@ internal struct ScanDecoder
         {
             int linesInInterval = Math.Min(FrameInfo.Height - line, _restartInterval);
 
-            for (int mcu = 0; mcu < linesInInterval; ++mcu, ++line)
+            for (int mcu = 0; ;)
             {
                 var previousLine = lineBuffer;
                 var currentLine = lineBuffer[pixelStride..];
-                if ((line & 1) == 1)
+                if ((mcu & 1) == 1)
                 {
                     var temp = previousLine;
                     previousLine = currentLine;
@@ -476,12 +485,21 @@ internal struct ScanDecoder
                 DecodeSampleLine(previousLine, currentLine);
 
                 CopyLineBufferToDestinationInterleaveNone(currentLine[1..], destination, FrameInfo.Width);
+
+                ++mcu;
+                if (mcu == linesInInterval)
+                {
+                    line += mcu;
+                    break;
+                }
+
                 destination = destination[stride..];
             }
 
             if (line == FrameInfo.Height)
                 break;
 
+            destination = destination[stride..];
             ProcessRestartMarker();
 
             // After a restart marker it is required to reset the decoder.
@@ -502,11 +520,11 @@ internal struct ScanDecoder
         {
             int linesInInterval = Math.Min(FrameInfo.Height - line, _restartInterval);
 
-            for (int mcu = 0; mcu < linesInInterval; ++mcu, ++line)
+            for (int mcu = 0; ;)
             {
                 var previousLine = lineBuffer;
                 var currentLine = lineBuffer[(componentCount * pixelStride)..];
-                bool oddLine = (line & 1) == 1;
+                bool oddLine = (mcu & 1) == 1;
                 if (oddLine)
                 {
                     var temp = previousLine;
@@ -531,12 +549,21 @@ internal struct ScanDecoder
 
                 int startPosition = (oddLine ? 0 : (pixelStride * componentCount)) + 1;
                 CopyLineBufferToDestinationInterleaveLine(lineBuffer[startPosition..], destination, FrameInfo.Width);
+
+                ++mcu;
+                if (mcu == linesInInterval)
+                {
+                    line += mcu;
+                    break;
+                }
+
                 destination = destination[stride..];
             }
 
             if (line == FrameInfo.Height)
                 break;
 
+            destination = destination[stride..];
             ProcessRestartMarker();
 
             // After a restart marker it is required to reset the decoder.
@@ -558,11 +585,11 @@ internal struct ScanDecoder
         {
             int linesInInterval = Math.Min(FrameInfo.Height - line, _restartInterval);
 
-            for (int mcu = 0; mcu < linesInInterval; ++mcu, ++line)
+            for (int mcu = 0; ;)
             {
                 var previousLine = lineBuffer;
                 var currentLine = lineBuffer[(componentCount * pixelStride)..];
-                bool oddLine = (line & 1) == 1;
+                bool oddLine = (mcu & 1) == 1;
                 if (oddLine)
                 {
                     var temp = previousLine;
@@ -587,12 +614,21 @@ internal struct ScanDecoder
 
                 int startPosition = (oddLine ? 0 : (pixelStride * componentCount)) + 1;
                 CopyLineBufferToDestinationInterleaveLine(lineBuffer[startPosition..], destination, FrameInfo.Width);
+
+                ++mcu;
+                if (mcu == linesInInterval)
+                {
+                    line += mcu;
+                    break;
+                }
+
                 destination = destination[stride..];
             }
 
             if (line == FrameInfo.Height)
                 break;
 
+            destination = destination[stride..];
             ProcessRestartMarker();
 
             // After a restart marker it is required to reset the decoder.
@@ -612,11 +648,11 @@ internal struct ScanDecoder
         {
             int linesInInterval = Math.Min(FrameInfo.Height - line, _restartInterval);
 
-            for (int mcu = 0; mcu < linesInInterval; ++mcu, ++line)
+            for (int mcu = 0; ;)
             {
                 var previousLine = lineBuffer;
                 var currentLine = lineBuffer[pixelStride..];
-                if ((line & 1) == 1)
+                if ((mcu & 1) == 1)
                 {
                     var temp = previousLine;
                     previousLine = currentLine;
@@ -630,12 +666,21 @@ internal struct ScanDecoder
                 DecodeTripletLine(previousLine, currentLine);
 
                 CopyLineBufferToDestination(currentLine[1..], destination, FrameInfo.Width);
+
+                ++mcu;
+                if (mcu == linesInInterval)
+                {
+                    line += mcu;
+                    break;
+                }
+
                 destination = destination[stride..];
             }
 
             if (line == FrameInfo.Height)
                 break;
 
+            destination = destination[stride..];
             ProcessRestartMarker();
 
             // After a restart marker it is required to reset the decoder.
@@ -654,11 +699,11 @@ internal struct ScanDecoder
         {
             int linesInInterval = Math.Min(FrameInfo.Height - line, _restartInterval);
 
-            for (int mcu = 0; mcu < linesInInterval; ++mcu, ++line)
+            for (int mcu = 0; ;)
             {
                 var previousLine = lineBuffer;
                 var currentLine = lineBuffer[pixelStride..];
-                if ((line & 1) == 1)
+                if ((mcu & 1) == 1)
                 {
                     var temp = previousLine;
                     previousLine = currentLine;
@@ -672,12 +717,21 @@ internal struct ScanDecoder
                 DecodeTripletLine(previousLine, currentLine);
 
                 CopyLineBufferToDestination(currentLine[1..], destination, FrameInfo.Width);
+
+                ++mcu;
+                if (mcu == linesInInterval)
+                {
+                    line += mcu;
+                    break;
+                }
+
                 destination = destination[stride..];
             }
 
             if (line == FrameInfo.Height)
                 break;
 
+            destination = destination[stride..];
             ProcessRestartMarker();
 
             // After a restart marker it is required to reset the decoder.
@@ -696,11 +750,11 @@ internal struct ScanDecoder
         {
             int linesInInterval = Math.Min(FrameInfo.Height - line, _restartInterval);
 
-            for (int mcu = 0; mcu < linesInInterval; ++mcu, ++line)
+            for (int mcu = 0; ;)
             {
                 var previousLine = lineBuffer;
                 var currentLine = lineBuffer[pixelStride..];
-                if ((line & 1) == 1)
+                if ((mcu & 1) == 1)
                 {
                     var temp = previousLine;
                     previousLine = currentLine;
@@ -714,12 +768,21 @@ internal struct ScanDecoder
                 DecodeQuadLine(previousLine, currentLine);
 
                 CopyLineBufferToDestination(currentLine[1..], destination, FrameInfo.Width);
+
+                ++mcu;
+                if (mcu == linesInInterval)
+                {
+                    line += mcu;
+                    break;
+                }
+
                 destination = destination[stride..];
             }
 
             if (line == FrameInfo.Height)
                 break;
 
+            destination = destination[stride..];
             ProcessRestartMarker();
 
             // After a restart marker it is required to reset the decoder.
@@ -738,11 +801,11 @@ internal struct ScanDecoder
         {
             int linesInInterval = Math.Min(FrameInfo.Height - line, _restartInterval);
 
-            for (int mcu = 0; mcu < linesInInterval; ++mcu, ++line)
+            for (int mcu = 0; ;)
             {
                 var previousLine = lineBuffer;
                 var currentLine = lineBuffer[pixelStride..];
-                if ((line & 1) == 1)
+                if ((mcu & 1) == 1)
                 {
                     var temp = previousLine;
                     previousLine = currentLine;
@@ -756,12 +819,21 @@ internal struct ScanDecoder
                 DecodeQuadLine(previousLine, currentLine);
 
                 CopyLineBufferToDestination(currentLine[1..], destination, FrameInfo.Width);
+
+                ++mcu;
+                if (mcu == linesInInterval)
+                {
+                    line += mcu;
+                    break;
+                }
+
                 destination = destination[stride..];
             }
 
             if (line == FrameInfo.Height)
                 break;
 
+            destination = destination[stride..];
             ProcessRestartMarker();
 
             // After a restart marker it is required to reset the decoder.

--- a/src/ScanEncoder.cs
+++ b/src/ScanEncoder.cs
@@ -22,7 +22,7 @@ internal struct ScanEncoder
 
     internal ScanEncoder(FrameInfo frameInfo, JpegLSPresetCodingParameters presetCodingParameters, CodingParameters codingParameters)
     {
-        var traits = Traits.Create(frameInfo, codingParameters.NearLossless);
+        var traits = Traits.Create(frameInfo.BitsPerSample, codingParameters.NearLossless);
         _scanCodec = new ScanCodec(traits, frameInfo, presetCodingParameters, codingParameters);
 
         _mask = (1 << frameInfo.BitsPerSample) - 1;

--- a/src/ThrowHelper.cs
+++ b/src/ThrowHelper.cs
@@ -107,7 +107,7 @@ internal static class ThrowHelper
             ErrorCode.ParameterValueNotSupported => "The JPEG-LS stream is encoded with a parameter value that is not supported by this decoder",
             ErrorCode.ColorTransformNotSupported => "The HP color transform is not supported",
             ErrorCode.JpegLSPresetExtendedParameterTypeNotSupported => "Unsupported JPEG-LS stream: JPEG-LS preset parameters segment contains a JPEG-LS Extended (ISO/IEC 14495-2) type",
-            ErrorCode.JpegMarkerStartByteNotFound => "Invalid JPEG-LS stream: first byte is not a JPEG marker start byte (0xFF)",
+            ErrorCode.JpegMarkerStartByteNotFound => "Invalid JPEG-LS stream: the leading start byte (0xFF) for a JPEG marker was not found",
             ErrorCode.StartOfImageMarkerNotFound => "Invalid JPEG-LS stream: first JPEG marker is not a Start Of Image (SOI) marker",
             ErrorCode.InvalidSpiffHeader => "Invalid JPEG-LS stream: invalid SPIFF header",
             ErrorCode.UnknownJpegMarkerFound => "Invalid JPEG-LS stream: an unknown JPEG marker code was found",

--- a/src/Traits.cs
+++ b/src/Traits.cs
@@ -103,14 +103,14 @@ internal class Traits
                Math.Abs(lhs.V3 - rhs.V3) <= NearLossless && Math.Abs(lhs.V4 - rhs.V4) <= NearLossless;
     }
 
-    internal static Traits Create(FrameInfo frameInfo, int nearLossless)
+    internal static Traits Create(int bitsPerSample, int nearLossless)
     {
-        int maximumSampleValue = CalculateMaximumSampleValue(frameInfo.BitsPerSample);
+        int maximumSampleValue = CalculateMaximumSampleValue(bitsPerSample);
 
         if (nearLossless != 0)
             return new Traits(maximumSampleValue, nearLossless);
 
-        return frameInfo.BitsPerSample switch
+        return bitsPerSample switch
         {
             8 => new LosslessTraits8(),
             16 => new LosslessTraits16(),

--- a/test/JpegLSEncoderTest.cs
+++ b/test/JpegLSEncoderTest.cs
@@ -1793,6 +1793,47 @@ public class JpegLSEncoderTest
         Assert.Equal(ErrorCode.InvalidArgumentColorTransformation, exception.GetErrorCode());
     }
 
+    [Fact]
+    public void EncodeTooManyComponentsInInterleaveModeSampleThrows()
+    {
+        JpegLSEncoder encoder = new()
+        {
+            FrameInfo = new FrameInfo(1, 1, 8, 5),
+            InterleaveMode = InterleaveMode.None
+        };
+
+        byte[] data = [24, 23, 22, 21, 20];
+
+        Memory<byte> encodedData = new byte[encoder.EstimatedDestinationSize];
+        encoder.Destination = encodedData;
+        encoder.InterleaveMode = InterleaveMode.Sample;
+
+        var exception = Assert.Throws<ArgumentException>(() => encoder.Encode(data));
+
+        Assert.False(string.IsNullOrEmpty(exception.Message));
+        Assert.Equal(ErrorCode.InvalidArgumentInterleaveMode, exception.GetErrorCode());
+    }
+
+    [Fact]
+    public void EncodeTooManyComponentsThrows()
+    {
+        JpegLSEncoder encoder = new()
+        {
+            FrameInfo = new FrameInfo(1, 1, 8, 3),
+            InterleaveMode = InterleaveMode.None
+        };
+
+        byte[] data = [24, 23, 22, 21];
+
+        Memory<byte> encodedData = new byte[encoder.EstimatedDestinationSize];
+        encoder.Destination = encodedData;
+
+        var exception = Assert.Throws<ArgumentException>(() => encoder.EncodeComponents(data, 4));
+
+        Assert.False(string.IsNullOrEmpty(exception.Message));
+        Assert.Equal(ErrorCode.InvalidArgument, exception.GetErrorCode());
+    }
+
     private static void EncodeWithCustomPresetCodingParameters(JpegLSPresetCodingParameters pcParameters)
     {
         byte[] source = [0, 1, 1, 1, 0];

--- a/test/JpegStreamReaderTest.cs
+++ b/test/JpegStreamReaderTest.cs
@@ -327,6 +327,51 @@ public class JpegStreamReaderTest
     }
 
     [Fact]
+    public void ReadHeaderWithToManyComponentsInStartOfFrameSegmentThrows()
+    {
+        JpegTestStreamWriter writer = new();
+        writer.WriteStartOfImage();
+        writer.WriteStartOfFrameSegment(512, 512, 8, 1);
+        writer.WriteStartOfScanSegment(1, 2, 0, InterleaveMode.Sample);
+        var reader = new JpegStreamReader { Source = writer.GetBuffer() };
+
+        var exception = Assert.Throws<InvalidDataException>(() => reader.ReadHeader(false));
+
+        Assert.False(string.IsNullOrEmpty(exception.Message));
+        Assert.Equal(ErrorCode.InvalidParameterComponentCount, exception.GetErrorCode());
+    }
+
+    [Fact]
+    public void ReadHeaderWithNoComponentsInStartOfFrameSegmentThrows()
+    {
+        JpegTestStreamWriter writer = new();
+        writer.WriteStartOfImage();
+        writer.WriteStartOfFrameSegment(512, 512, 8, 1);
+        writer.WriteStartOfScanSegment(1, 0, 0, InterleaveMode.None);
+        var reader = new JpegStreamReader { Source = writer.GetBuffer() };
+
+        var exception = Assert.Throws<InvalidDataException>(() => reader.ReadHeader(false));
+
+        Assert.False(string.IsNullOrEmpty(exception.Message));
+        Assert.Equal(ErrorCode.InvalidParameterComponentCount, exception.GetErrorCode());
+    }
+
+    [Fact]
+    public void ReadHeaderWithMoreThenMaxComponentsInStartOfFrameSegmentThrows()
+    {
+        JpegTestStreamWriter writer = new();
+        writer.WriteStartOfImage();
+        writer.WriteStartOfFrameSegment(512, 512, 8, 5);
+        writer.WriteStartOfScanSegment(1, 5, 0, InterleaveMode.Sample);
+        var reader = new JpegStreamReader { Source = writer.GetBuffer() };
+
+        var exception = Assert.Throws<InvalidDataException>(() => reader.ReadHeader(false));
+
+        Assert.False(string.IsNullOrEmpty(exception.Message));
+        Assert.Equal(ErrorCode.InvalidParameterComponentCount, exception.GetErrorCode());
+    }
+
+    [Fact]
     public void ReadHeaderWithTooSmallStartOfScanShouldThrow()
     {
         byte[] buffer =


### PR DESCRIPTION
Add an additional method for advanced encodings scenarios. This methods allow to encode components with different coding parameters like: near lossless, jpeg-ls preset coding parameters or scans with different interleave modes. Extend the decoder to also be able to decode scans with different interleave modes.