### PR TITLE
Add support for DNL segments with lines > 2^16

### DIFF
--- a/src/JpegStreamReader.cs
+++ b/src/JpegStreamReader.cs
@@ -664,6 +664,19 @@ internal struct JpegStreamReader
         };
     }
 
+    private int ReadDefineNumberOfLinesSegment()
+    {
+        // Note: The JPEG-LS standard supports a 2, 3 or 4 byte restart interval (see ISO/IEC 14495-1, C.2.6)
+        //       The original JPEG standard only supports 2 bytes (16 bit big endian).
+        return _segmentDataSize switch
+        {
+            2 => ReadUint16(),
+            3 => ReadUint24(),
+            4 => ReadUint32(),
+            _ => throw ThrowHelper.CreateInvalidDataException(ErrorCode.InvalidMarkerSegmentSize)
+        };
+    }
+
     private void ReadStartOfScanSegment()
     {
         CheckMinimalSegmentSize(1);
@@ -925,12 +938,6 @@ internal struct JpegStreamReader
         }
 
         ThrowHelper.ThrowInvalidDataException(ErrorCode.DefineNumberOfLinesMarkerNotFound);
-    }
-
-    private int ReadDefineNumberOfLinesSegment()
-    {
-        CheckSegmentSize(2);
-        return ReadUint16();
     }
 
     private static bool IsKnownJpegSofMarker(JpegMarkerCode markerCode)

--- a/test/JpegStreamReaderTest.cs
+++ b/test/JpegStreamReaderTest.cs
@@ -810,19 +810,69 @@ public class JpegStreamReaderTest
     }
 
     [Fact]
-    public void ReadDefineNumberOfLines()
+    public void ReadDefineNumberOfLines16Bit()
     {
         JpegTestStreamWriter writer = new();
         writer.WriteStartOfImage();
         writer.WriteStartOfFrameSegment(1, 0, 2, 3);
         writer.WriteStartOfScanSegment(0, 3, 0, InterleaveMode.Sample);
         writer.WriteBytes([0, 1, 0xFF, 5]);
-        writer.WriteDefineNumberOfLines(1);
+        writer.WriteDefineNumberOfLines(1, 2);
 
         JpegStreamReader reader = new() { Source = writer.GetBuffer() };
         reader.ReadHeader(true);
 
         Assert.Equal(1, reader.FrameInfo.Height);
+    }
+
+    [Fact]
+    public void ReadDefineNumberOfLines24Bit()
+    {
+        JpegTestStreamWriter writer = new();
+        writer.WriteStartOfImage();
+        writer.WriteStartOfFrameSegment(1, 0, 2, 3);
+        writer.WriteStartOfScanSegment(0, 3, 0, InterleaveMode.Sample);
+        writer.WriteBytes([0, 1, 0xFF, 5]);
+        writer.WriteDefineNumberOfLines(1, 3);
+
+        JpegStreamReader reader = new() { Source = writer.GetBuffer() };
+        reader.ReadHeader(true);
+
+        Assert.Equal(1, reader.FrameInfo.Height);
+    }
+
+    [Fact]
+    public void ReadDefineNumberOfLines32Bit()
+    {
+        JpegTestStreamWriter writer = new();
+        writer.WriteStartOfImage();
+        writer.WriteStartOfFrameSegment(1, 0, 2, 3);
+        writer.WriteStartOfScanSegment(0, 3, 0, InterleaveMode.Sample);
+        writer.WriteBytes([0, 1, 0xFF, 5]);
+        writer.WriteDefineNumberOfLines(1, 4);
+
+        JpegStreamReader reader = new() { Source = writer.GetBuffer() };
+        reader.ReadHeader(true);
+
+        Assert.Equal(1, reader.FrameInfo.Height);
+    }
+
+    [Fact]
+    public void ReadDefineNumberOfLines32BitOverFlowThrows()
+    {
+        JpegTestStreamWriter writer = new();
+        writer.WriteStartOfImage();
+        writer.WriteStartOfFrameSegment(1, 0, 2, 3);
+        writer.WriteStartOfScanSegment(0, 3, 0, InterleaveMode.Sample);
+        writer.WriteBytes([0, 1, 0xFF, 5]);
+        writer.WriteDefineNumberOfLines(uint.MaxValue, 4);
+
+        JpegStreamReader reader = new() { Source = writer.GetBuffer() };
+
+        var exception = Assert.Throws<InvalidDataException>(() => reader.ReadHeader(false));
+
+        Assert.False(string.IsNullOrEmpty(exception.Message));
+        Assert.Equal(ErrorCode.ParameterValueNotSupported, exception.GetErrorCode());
     }
 
     [Fact]
@@ -832,7 +882,7 @@ public class JpegStreamReaderTest
         writer.WriteStartOfImage();
         writer.WriteStartOfFrameSegment(1, 0, 2, 3);
         writer.WriteStartOfScanSegment(0, 3, 0, InterleaveMode.Sample);
-        writer.WriteDefineNumberOfLines(0);
+        writer.WriteDefineNumberOfLines(0, 2);
 
         JpegStreamReader reader = new() { Source = writer.GetBuffer() };
 
@@ -865,7 +915,7 @@ public class JpegStreamReaderTest
         JpegTestStreamWriter writer = new();
         writer.WriteStartOfImage();
         writer.WriteStartOfFrameSegment(1, 0, 2, 3);
-        writer.WriteDefineNumberOfLines(1);
+        writer.WriteDefineNumberOfLines(1, 2);
         writer.WriteStartOfScanSegment(0, 3, 0, InterleaveMode.Sample);
         writer.WriteMarker(JpegMarkerCode.EndOfImage);
 
@@ -884,8 +934,8 @@ public class JpegStreamReaderTest
         writer.WriteStartOfImage();
         writer.WriteStartOfFrameSegment(1, 0, 2, 3);
         writer.WriteStartOfScanSegment(0, 3, 0, InterleaveMode.Sample);
-        writer.WriteDefineNumberOfLines(1);
-        writer.WriteDefineNumberOfLines(1);
+        writer.WriteDefineNumberOfLines(1, 2);
+        writer.WriteDefineNumberOfLines(1, 2);
 
         JpegStreamReader reader = new() { Source = writer.GetBuffer() };
 

--- a/test/JpegTestStreamWriter.cs
+++ b/test/JpegTestStreamWriter.cs
@@ -198,6 +198,7 @@ internal sealed class JpegTestStreamWriter
 
     internal void WriteDefineRestartInterval(uint restartInterval, int size)
     {
+        // Segment is documented in C.2.5
         WriteSegmentStart(JpegMarkerCode.DefineRestartInterval, size);
 
         switch (size)
@@ -216,10 +217,24 @@ internal sealed class JpegTestStreamWriter
         }
     }
 
-    internal void WriteDefineNumberOfLines(int height)
+    internal void WriteDefineNumberOfLines(uint height, int size)
     {
-        WriteSegmentStart(JpegMarkerCode.DefineNumberOfLines, 2);
-        WriteUint16(height);
+        // Segment is documented in C.2.6
+        WriteSegmentStart(JpegMarkerCode.DefineNumberOfLines, size);
+        switch (size)
+        {
+            case 2:
+                WriteUint16((int)height);
+                break;
+
+            case 3:
+                WriteUint24(height);
+                break;
+
+            case 4:
+                WriteUint32(height);
+                break;
+        }
     }
 
     internal void WriteColorTransformSegment(ColorTransformation colorTransformation)


### PR DESCRIPTION
Section ISO/IEC 14495-1, C.2.6 specifies that JPEG-LS allows DNL segments with a length between 4 and 6 bytes. Update the code to handle these DNL segments.