### PR TITLE
Replace property JpegLsDecoder.InterleaveMode with method GetInterleaveMode

### DIFF
--- a/src/JpegLSEncoder.cs
+++ b/src/JpegLSEncoder.cs
@@ -308,7 +308,7 @@ public sealed class JpegLSEncoder
         ThrowHelper.ThrowInvalidOperationIfFalse(IsFrameInfoConfigured);
         ThrowHelper.ThrowArgumentExceptionIfFalse(sourceComponentCount <= FrameInfo.ComponentCount - _encodedComponentCount, nameof(sourceComponentCount));
         CheckInterleaveModeAgainstComponentCount(sourceComponentCount);
-        stride = CheckStrideAndSourceLength(source.Length, stride, sourceComponentCount);
+        int scanStride = CheckStrideAndSourceLength(source.Length, stride, sourceComponentCount);
 
         int maximumSampleValue = CalculateMaximumSampleValue(FrameInfo.BitsPerSample);
         if (!_userPresetCodingParameters!.TryMakeExplicit(maximumSampleValue, NearLossless, out var explicitCodingParameters))
@@ -325,11 +325,11 @@ public sealed class JpegLSEncoder
 
         if (InterleaveMode == InterleaveMode.None)
         {
-            int byteCountComponent = stride * FrameInfo.Height;
+            int byteCountComponent = scanStride * FrameInfo.Height;
             for (int component = 0; ;)
             {
                 _writer.WriteStartOfScanSegment(1, NearLossless, InterleaveMode);
-                EncodeScan(source, stride, 1, explicitCodingParameters);
+                EncodeScan(source, scanStride, 1, explicitCodingParameters);
 
                 ++component;
                 if (component == sourceComponentCount)
@@ -342,7 +342,7 @@ public sealed class JpegLSEncoder
         else
         {
             _writer.WriteStartOfScanSegment(sourceComponentCount, NearLossless, InterleaveMode);
-            EncodeScan(source, stride, sourceComponentCount, explicitCodingParameters);
+            EncodeScan(source, scanStride, sourceComponentCount, explicitCodingParameters);
         }
 
         _encodedComponentCount += sourceComponentCount;

--- a/test/ComplianceTest.cs
+++ b/test/ComplianceTest.cs
@@ -205,7 +205,7 @@ public class ComplianceTest
 
         JpegLSDecoder decoder = new(encodedSource);
 
-        var referenceFile = Util.ReadAnymapReferenceFile(rawFilename, decoder.InterleaveMode, decoder.FrameInfo);
+        var referenceFile = Util.ReadAnymapReferenceFile(rawFilename, decoder.GetInterleaveMode(), decoder.FrameInfo);
 
         Util.TestCompliance(encodedSource, referenceFile.ImageData, checkEncode);
     }

--- a/test/EncodeTest.cs
+++ b/test/EncodeTest.cs
@@ -279,6 +279,9 @@ public class EncodeTest
         decoder.Decode(destination);
 
         CheckOutput(data, destination, decoder, 3, decoder.FrameInfo.Height * decoder.FrameInfo.Width);
+        Assert.Equal(0, decoder.GetNearLossless());
+        Assert.Equal(2, decoder.GetNearLossless(1));
+        Assert.Equal(10, decoder.GetNearLossless(2));
     }
 
     [Fact]
@@ -353,6 +356,10 @@ public class EncodeTest
 
         CheckOutput(component0, destination, decoder, 1, 8 * 2);
         CheckOutput(component1And2And3, destination[(8 * 2)..], decoder, 1, 8 * 2 * 3);
+        Assert.Equal(InterleaveMode.None, decoder.GetInterleaveMode());
+        Assert.Equal(InterleaveMode.Sample, decoder.GetInterleaveMode(1));
+        Assert.Equal(InterleaveMode.Sample, decoder.GetInterleaveMode(2));
+        Assert.Equal(InterleaveMode.Sample, decoder.GetInterleaveMode(3));
     }
 
     [Fact]
@@ -393,6 +400,10 @@ public class EncodeTest
 
         CheckOutput(component0And1And2, destination, decoder, 1, 8 * 2 * 3);
         CheckOutput(component3, destination[(8*2*3)..], decoder, 1, 8 * 2);
+        Assert.Equal(InterleaveMode.Sample, decoder.GetInterleaveMode());
+        Assert.Equal(InterleaveMode.Sample, decoder.GetInterleaveMode(1));
+        Assert.Equal(InterleaveMode.Sample, decoder.GetInterleaveMode(2));
+        Assert.Equal(InterleaveMode.None, decoder.GetInterleaveMode(3));
     }
 
     private static void CheckOutput(Span<byte> source, Span<byte> destination, JpegLSDecoder decoder, int componentCount, int componentSize)

--- a/test/JpegLSDecoderTest.cs
+++ b/test/JpegLSDecoderTest.cs
@@ -82,7 +82,7 @@ public class JpegLSDecoderTest
         var buffer = new byte[2000];
         JpegLSDecoder decoder = new() { Source = buffer };
 
-        var exception = Assert.Throws<InvalidOperationException>(() => decoder.InterleaveMode);
+        var exception = Assert.Throws<InvalidOperationException>(() => decoder.GetInterleaveMode());
 
         Assert.False(string.IsNullOrEmpty(exception.Message));
         Assert.Equal(ErrorCode.InvalidOperation, exception.GetErrorCode());
@@ -159,7 +159,7 @@ public class JpegLSDecoderTest
 
         decoder.Decode(destination);
 
-        var referenceFile = Util.ReadAnymapReferenceFile("conformance/test8.ppm", decoder.InterleaveMode, decoder.FrameInfo);
+        var referenceFile = Util.ReadAnymapReferenceFile("conformance/test8.ppm", decoder.GetInterleaveMode(), decoder.FrameInfo);
         var referenceImageData = referenceFile.ImageData;
         for (int i = 0; i != destination.Length; ++i)
         {
@@ -177,7 +177,7 @@ public class JpegLSDecoderTest
         byte[] destination = new byte[decoder.GetDestinationSize()];
         decoder.Decode(destination);
 
-        var referenceFile = Util.ReadAnymapReferenceFile("conformance/test8.ppm", decoder.InterleaveMode, decoder.FrameInfo);
+        var referenceFile = Util.ReadAnymapReferenceFile("conformance/test8.ppm", decoder.GetInterleaveMode(), decoder.FrameInfo);
         var referenceImageData = referenceFile.ImageData;
         for (int i = 0; i != destination.Length; ++i)
         {
@@ -193,7 +193,7 @@ public class JpegLSDecoderTest
 
         var destination = decoder.Decode();
 
-        var referenceFile = Util.ReadAnymapReferenceFile("conformance/test8.ppm", decoder.InterleaveMode, decoder.FrameInfo);
+        var referenceFile = Util.ReadAnymapReferenceFile("conformance/test8.ppm", decoder.GetInterleaveMode(), decoder.FrameInfo);
         var referenceImageData = referenceFile.ImageData;
         for (int i = 0; i != destination.Length; ++i)
         {
@@ -278,7 +278,7 @@ public class JpegLSDecoderTest
 
         decoder.Decode(destination, standardStride);
 
-        Util.VerifyDecodedBytes(decoder.InterleaveMode, decoder.FrameInfo, destination, standardStride, "conformance/test8.ppm");
+        Util.VerifyDecodedBytes(decoder.GetInterleaveMode(), decoder.FrameInfo, destination, standardStride, "conformance/test8.ppm");
     }
 
     [Fact]
@@ -292,7 +292,7 @@ public class JpegLSDecoderTest
 
         decoder.Decode(destination, standardStride);
 
-        Util.VerifyDecodedBytes(decoder.InterleaveMode, decoder.FrameInfo, destination, standardStride, "conformance/test8.ppm");
+        Util.VerifyDecodedBytes(decoder.GetInterleaveMode(), decoder.FrameInfo, destination, standardStride, "conformance/test8.ppm");
     }
 
     [Fact]
@@ -306,7 +306,7 @@ public class JpegLSDecoderTest
 
         decoder.Decode(destination, customStride);
 
-        Util.VerifyDecodedBytes(decoder.InterleaveMode, decoder.FrameInfo, destination, customStride, "conformance/test8.ppm");
+        Util.VerifyDecodedBytes(decoder.GetInterleaveMode(), decoder.FrameInfo, destination, customStride, "conformance/test8.ppm");
     }
 
     [Fact]
@@ -320,7 +320,7 @@ public class JpegLSDecoderTest
 
         decoder.Decode(destination, customStride);
 
-        Util.VerifyDecodedBytes(decoder.InterleaveMode, decoder.FrameInfo, destination, customStride, "conformance/test8.ppm");
+        Util.VerifyDecodedBytes(decoder.GetInterleaveMode(), decoder.FrameInfo, destination, customStride, "conformance/test8.ppm");
     }
 
     [Fact]
@@ -476,7 +476,7 @@ public class JpegLSDecoderTest
         source = ArrayInsert(position, source, extraBeginBytes);
 
         JpegLSDecoder decoder = new(source);
-        var referenceFile = Util.ReadAnymapReferenceFile("conformance/test8.ppm", decoder.InterleaveMode, decoder.FrameInfo);
+        var referenceFile = Util.ReadAnymapReferenceFile("conformance/test8.ppm", decoder.GetInterleaveMode(), decoder.FrameInfo);
         Util.TestCompliance(source, referenceFile.ImageData, false);
     }
 

--- a/test/JpegStreamReaderTest.cs
+++ b/test/JpegStreamReaderTest.cs
@@ -815,12 +815,13 @@ public class JpegStreamReaderTest
         JpegTestStreamWriter writer = new();
         writer.WriteStartOfImage();
         writer.WriteStartOfFrameSegment(1, 0, 2, 3);
-        writer.WriteStartOfScanSegment(0, 3, 0, InterleaveMode.Sample);
-        writer.WriteBytes([0, 1, 0xFF, 5]);
+        writer.WriteStartOfScanSegment(0, 1, 0, InterleaveMode.None);
         writer.WriteDefineNumberOfLines(1, 2);
+        writer.WriteStartOfScanSegment(1, 1, 0, InterleaveMode.None);
 
         JpegStreamReader reader = new() { Source = writer.GetBuffer() };
         reader.ReadHeader(true);
+        reader.ReadNextStartOfScan();
 
         Assert.Equal(1, reader.FrameInfo.Height);
     }
@@ -831,12 +832,13 @@ public class JpegStreamReaderTest
         JpegTestStreamWriter writer = new();
         writer.WriteStartOfImage();
         writer.WriteStartOfFrameSegment(1, 0, 2, 3);
-        writer.WriteStartOfScanSegment(0, 3, 0, InterleaveMode.Sample);
-        writer.WriteBytes([0, 1, 0xFF, 5]);
+        writer.WriteStartOfScanSegment(0, 1, 0, InterleaveMode.None);
         writer.WriteDefineNumberOfLines(1, 3);
+        writer.WriteStartOfScanSegment(1, 1, 0, InterleaveMode.None);
 
         JpegStreamReader reader = new() { Source = writer.GetBuffer() };
         reader.ReadHeader(true);
+        reader.ReadNextStartOfScan();
 
         Assert.Equal(1, reader.FrameInfo.Height);
     }
@@ -847,12 +849,13 @@ public class JpegStreamReaderTest
         JpegTestStreamWriter writer = new();
         writer.WriteStartOfImage();
         writer.WriteStartOfFrameSegment(1, 0, 2, 3);
-        writer.WriteStartOfScanSegment(0, 3, 0, InterleaveMode.Sample);
-        writer.WriteBytes([0, 1, 0xFF, 5]);
+        writer.WriteStartOfScanSegment(0, 1, 0, InterleaveMode.None);
         writer.WriteDefineNumberOfLines(1, 4);
+        writer.WriteStartOfScanSegment(1, 1, 0, InterleaveMode.None);
 
         JpegStreamReader reader = new() { Source = writer.GetBuffer() };
         reader.ReadHeader(true);
+        reader.ReadNextStartOfScan();
 
         Assert.Equal(1, reader.FrameInfo.Height);
     }

--- a/test/Util.cs
+++ b/test/Util.cs
@@ -122,7 +122,7 @@ internal static class Util
         Assert.Equal(sourceFrameInfo.Height, frameInfo.Height);
         Assert.Equal(sourceFrameInfo.BitsPerSample, frameInfo.BitsPerSample);
         Assert.Equal(sourceFrameInfo.ComponentCount, frameInfo.ComponentCount);
-        Assert.Equal(interleaveMode, decoder.InterleaveMode);
+        Assert.Equal(interleaveMode, decoder.GetInterleaveMode());
         Assert.Equal(colorTransformation, decoder.ColorTransformation);
 
         var destination = new byte[decoder.GetDestinationSize()];
@@ -235,7 +235,7 @@ internal static class Util
         {
             Destination = ourEncodedBytes,
             FrameInfo = decoder.FrameInfo,
-            InterleaveMode = decoder.InterleaveMode,
+            InterleaveMode = decoder.GetInterleaveMode(),
             NearLossless = decoder.GetNearLossless(),
             PresetCodingParameters = decoder.PresetCodingParameters
         };


### PR DESCRIPTION
It is allowed in JPEG-LS to use different interleave modes for different scans. To correctly get the interleave mode for a component the component index needs to be passed.