### PR TITLE
Add support for AOT compilation in .NET 8.0 and later

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - New property JpegLSDecoder.CompressedDataFormat to retrieve the compressed data format of
 the JPEG-LS file. JPEG-LS defines 3 formats: 1 interchange (most common) and 2 abbreviated.
-- Added support for AOT compilation in .NET 8 and later.
+- Added support for AOT compilation in .NET 8.0 and later.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - New property JpegLSDecoder.CompressedDataFormat to retrieve the compressed data format of
 the JPEG-LS file. JPEG-LS defines 3 formats: 1 interchange (most common) and 2 abbreviated.
+- Added support for AOT compilation in .NET 8 and later.
 
 ### Changed
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,6 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.2" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageVersion Include="System.Drawing.Common" Version="9.0.7" />
+    <PackageVersion Include="System.Drawing.Common" Version="9.0.8" />
   </ItemGroup>
 </Project>

--- a/src/CharLS.Managed.csproj
+++ b/src/CharLS.Managed.csproj
@@ -9,6 +9,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>CharLS.Managed</RootNamespace>
+    <IsAotCompatible>true</IsAotCompatible>
 
     <!-- Use strong naming -->
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
Allow project that use the assembly to publish their project as an AOT binary.